### PR TITLE
Because ImageIO is not working, enable the old codecs as fallback.

### DIFF
--- a/batik-codec/src/main/resources/META-INF/services/org.apache.batik.ext.awt.image.spi.RegistryEntry
+++ b/batik-codec/src/main/resources/META-INF/services/org.apache.batik.ext.awt.image.spi.RegistryEntry
@@ -22,7 +22,8 @@
 
 # NOTE: the "codec" package is deprecated, there entries are kept here for compatibility with older JVM versions
 # (uses "sun.image", which is only supported in Sun Java implementations and was retired in JDK 7)
-#org.apache.batik.ext.awt.image.codec.png.PNGRegistryEntry
+org.apache.batik.ext.awt.image.codec.png.PNGRegistryEntry
+org.apache.batik.ext.awt.image.codec.tiff.TIFFRegistryEntry
 
 org.apache.batik.ext.awt.image.codec.imageio.ImageIOJPEGRegistryEntry
 org.apache.batik.ext.awt.image.codec.imageio.ImageIOPNGRegistryEntry


### PR DESCRIPTION
The ImageIO entries are missing from the Maven build.
To have at least some working entry, enable the compatibility entries.
